### PR TITLE
Added RooCode

### DIFF
--- a/src/data/ai-environments.ts
+++ b/src/data/ai-environments.ts
@@ -5,6 +5,7 @@ export enum AIEnvironmentName {
   Aider = 'aider',
   Cline = 'cline',
   Junie = 'junie',
+  RooCode = 'roocode',
 }
 
 // Define the AI environment types for easier maintenance
@@ -42,5 +43,10 @@ export const aiEnvironmentConfig: AIEnvironmentConfig = {
   junie: {
     filePath: '.junie/guidelines.md',
     docsUrl: 'https://www.jetbrains.com/guide/ai/article/junie/intellij-idea/',
+  },
+  roocode: {
+    filePath: '.roo/rules/{rule}.md',
+    docsUrl:
+      'https://docs.roocode.com/features/custom-instructions?_highlight=rules#rules-about-rules-files',
   },
 };


### PR DESCRIPTION
[Roo Code](https://roocode.com/) was forked from Cline in January 2025 and is about as popular as Cline now. (even surpassing it on OpenRouter Top Apps as of 15 April 2025)
![image](https://github.com/user-attachments/assets/234f1718-fee0-4b41-b49e-c77775a98171)

This PR is simple, just updated ai-environments.ts with the slug and the appropriate docs url. 

