### PR TITLE
Add Quarkus configuration

### DIFF
--- a/src/data/dictionaries.ts
+++ b/src/data/dictionaries.ts
@@ -104,6 +104,7 @@ export enum Library {
   SPRING_BOOT = 'SPRING_BOOT',
   SPRING_DATA_JPA = 'SPRING_DATA_JPA',
   LOMBOK = 'LOMBOK',
+  QUARKUS = 'QUARKUS',
 
   // .NET libraries
   ENTITY_FRAMEWORK = 'ENTITY_FRAMEWORK',
@@ -251,7 +252,7 @@ export const stackToLibraryMap: StackToLibraryMap = {
   [Stack.STYLING]: [Library.TAILWIND, Library.STYLED_COMPONENTS, Library.SCSS],
   [Stack.NODE]: [Library.EXPRESS, Library.NEST, Library.FASTIFY],
   [Stack.PYTHON]: [Library.DJANGO, Library.FLASK, Library.FASTAPI],
-  [Stack.JAVA]: [Library.SPRING_BOOT, Library.SPRING_DATA_JPA, Library.LOMBOK],
+  [Stack.JAVA]: [Library.SPRING_BOOT, Library.SPRING_DATA_JPA, Library.LOMBOK, Library.QUARKUS],
   [Stack.DOTNET]: [Library.ENTITY_FRAMEWORK, Library.ASP_NET],
   [Stack.GO]: [Library.GIN, Library.ECHO],
   [Stack.SQL]: [Library.POSTGRES, Library.MYSQL, Library.SQLSERVER],

--- a/src/data/rules/backend.ts
+++ b/src/data/rules/backend.ts
@@ -75,6 +75,16 @@ export const backendRules: LibraryRulesMap = {
     'Use `Optional` to avoid `NullPointerException`',
   ],
 
+  [Library.QUARKUS]: [
+    'Use CDI annotations (`@Inject`, `@ApplicationScoped`, etc.) for dependency injection following Jakarta EE standards',
+    'Leverage Quarkus extensions and optimizations for GraalVM native builds to reduce startup time and memory usage',
+    'Implement reactive programming with Mutiny or Vert.x for non-blocking I/O operations for {{high_load_endpoints}}',
+    'Use MicroProfile Config (`@ConfigProperty`) for type-safe configuration injection from application.properties',
+    'Implement health checks and metrics with MicroProfile Health and Metrics for {{critical_services}}',
+    'Structure your application with clear separation of resources, services, and repositories following RESTful conventions',
+    'Use Quarkus Dev Mode with live reload for faster development cycles and debugging',
+  ],
+
   [Library.SPRING_DATA_JPA]: [
     'Define repositories as interfaces extending `JpaRepository` or `CrudRepository`',
     'Never expose JPA entities in API responses – always map them to DTOs',

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -97,6 +97,7 @@ export const libraryTranslations: Record<Library, string> = {
   SPRING_BOOT: 'Spring',
   SPRING_DATA_JPA: 'Spring Data JPA',
   LOMBOK: 'Lombok',
+  QUARKUS: 'Quarkus',
 
   // .NET libraries
   ENTITY_FRAMEWORK: 'Entity Framework',


### PR DESCRIPTION
# Description

This PR adds support for Quarkus framework to the Java stack in the rules builder. Quarkus is a Kubernetes-native Java framework tailored for GraalVM and HotSpot, designed to make Java a leading platform in Kubernetes and serverless environments.

The changes include:
- Added QUARKUS to the Library enum in dictionaries.ts
- Added QUARKUS to the JAVA stack libraries list
- Added Quarkus rules to the backendRules object following existing patterns
- Added translation for "Quarkus" in translations.ts
- Ensured consistent code formatting with backticks for class/annotation names

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Unit Tests
  - Verified that all tests pass including dictionary integrity tests
  - Confirmed translations test passes with the new Quarkus entry

