### PR TITLE
feat: add support for github split instructions

### DIFF
--- a/src/components/rule-preview/RulePreview.tsx
+++ b/src/components/rule-preview/RulePreview.tsx
@@ -8,6 +8,7 @@ import { DependencyUpload } from './DependencyUpload.tsx';
 import { MarkdownContentRenderer } from './MarkdownContentRenderer.tsx';
 import type { RulesContent } from '../../services/rules-builder/RulesBuilderTypes.ts';
 import { JsonContentRenderer } from '../settings-preview/SettingsPreview.tsx';
+import { AIEnvironmentName } from '@/data/ai-environments.ts';
 
 export const RulePreview: React.FC = () => {
   const { selectedLibraries } = useTechStackStore();
@@ -21,12 +22,17 @@ export const RulePreview: React.FC = () => {
   useEffect(() => {
     const shouldDisplaySettings =
       adaptableFileEnvironments.has(selectedEnvironment) && isMultiFileEnvironment;
+
+    const extension =
+      AIEnvironmentName.GitHub && isMultiFileEnvironment ? 'instructions.md' : 'mdc';
+
     const settings = RulesBuilderService.generateSettingsContent(selectedLibraries);
     const markdowns = RulesBuilderService.generateRulesContent(
       projectName,
       projectDescription,
       selectedLibraries,
       isMultiFileEnvironment,
+      extension,
     );
     setMarkdownContent(markdowns);
     setSettingsContent(shouldDisplaySettings ? settings : []);

--- a/src/components/rule-preview/RulePreviewTopbar.tsx
+++ b/src/components/rule-preview/RulePreviewTopbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useProjectStore } from '../../store/projectStore';
+import { useProjectStore, adaptableFileEnvironments } from '../../store/projectStore';
 import { RulesPath } from './RulesPath';
 import { RulesPreviewActions } from './RulesPreviewActions';
 import type { RulesContent } from '../../services/rules-builder/RulesBuilderTypes.ts';
@@ -37,8 +37,13 @@ const EnvButton: React.FC<EnvButtonProps> = ({
 };
 
 export const RulePreviewTopbar: React.FC<RulePreviewTopbarProps> = ({ rulesContent }) => {
-  const { selectedEnvironment, setSelectedEnvironment, isMultiFileEnvironment, isHydrated } =
-    useProjectStore();
+  const {
+    selectedEnvironment,
+    setSelectedEnvironment,
+    isMultiFileEnvironment,
+    isHydrated,
+    setMultiFileEnvironment,
+  } = useProjectStore();
 
   // If state hasn't been hydrated from storage yet, don't render the selector
   // This prevents the "blinking" effect when loading persisted state
@@ -85,6 +90,36 @@ export const RulePreviewTopbar: React.FC<RulePreviewTopbarProps> = ({ rulesConte
 
           {/* Path display */}
           <RulesPath />
+
+          {adaptableFileEnvironments.has(selectedEnvironment) && (
+            <div
+              className="flex items-center space-x-2"
+              role="group"
+              aria-labelledby="multi-file-label"
+            >
+              <div className="relative flex items-center">
+                <input
+                  type="checkbox"
+                  id="multiFileToggle"
+                  name="multiFileToggle"
+                  checked={isMultiFileEnvironment}
+                  onChange={(e) => setMultiFileEnvironment(e.target.checked)}
+                  aria-describedby="multi-file-description"
+                  className="w-4 h-4 rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-2 focus:ring-offset-gray-800"
+                />
+                <label
+                  id="multi-file-label"
+                  htmlFor="multiFileToggle"
+                  className="ml-2 text-sm text-gray-300 select-none cursor-pointer"
+                >
+                  Split instructions into domain files
+                </label>
+              </div>
+              <span id="multi-file-description" className="sr-only">
+                When enabled, instructions will be split into separate domain-specific files
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Right side: Action buttons */}

--- a/src/components/rule-preview/RulesPath.tsx
+++ b/src/components/rule-preview/RulesPath.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
-import { useProjectStore } from '../../store/projectStore';
+import { adaptableFileEnvironments, useProjectStore } from '../../store/projectStore';
 import { aiEnvironmentConfig } from '../../data/ai-environments.ts';
 
 export const RulesPath: React.FC = () => {
-  const { selectedEnvironment } = useProjectStore();
+  const { selectedEnvironment, isMultiFileEnvironment } = useProjectStore();
 
   // Get the appropriate file path based on the selected format
-  const getFilePath = (): string => aiEnvironmentConfig[selectedEnvironment].filePath;
+  const shouldUseAlternativePath =
+    isMultiFileEnvironment && adaptableFileEnvironments.has(selectedEnvironment);
+
+  const getFilePath = (): string => {
+    const config = aiEnvironmentConfig[selectedEnvironment];
+
+    return shouldUseAlternativePath && config.alternativeFilePath
+      ? config.alternativeFilePath
+      : config.filePath;
+  };
 
   return (
     <div className="text-sm text-gray-400 w-full break-all">

--- a/src/components/rule-preview/RulesPreviewCopyDownloadActions.tsx
+++ b/src/components/rule-preview/RulesPreviewCopyDownloadActions.tsx
@@ -6,10 +6,12 @@ import { useProjectStore } from '../../store/projectStore';
 
 interface RulesPreviewCopyDownloadActionsProps {
   rulesContent: RulesContent[];
+  filePath?: string;
 }
 
 export const RulesPreviewCopyDownloadActions: React.FC<RulesPreviewCopyDownloadActionsProps> = ({
   rulesContent,
+  filePath,
 }) => {
   const { selectedEnvironment, isMultiFileEnvironment } = useProjectStore();
   const [showCopiedMessage, setShowCopiedMessage] = useState(false);
@@ -85,7 +87,7 @@ export const RulesPreviewCopyDownloadActions: React.FC<RulesPreviewCopyDownloadA
     } else {
       content = rulesContent[0].markdown;
       blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
-      download = getFilePath().split('/').pop() || `${selectedEnvironment}-rules.md`;
+      download = filePath || getFilePath().split('/').pop() || `${selectedEnvironment}-rules.md`;
     }
 
     const url = URL.createObjectURL(blob);

--- a/src/components/settings-preview/SettingsPreview.tsx
+++ b/src/components/settings-preview/SettingsPreview.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import type { RulesContent } from '../../services/rules-builder/RulesBuilderTypes.ts';
+import RulesPreviewCopyDownloadActions from '../rule-preview/RulesPreviewCopyDownloadActions.tsx';
+
+// Helper function to format JSON with proper indentation and syntax highlighting
+const formatJsonWithSyntaxHighlighting = (jsonContent: string): JSX.Element => {
+  try {
+    // Parse and re-stringify for proper formatting
+    const parsed = JSON.parse(jsonContent);
+    const formatted = JSON.stringify(parsed, null, 2);
+
+    // Basic syntax highlighting
+    return (
+      <code className="font-mono text-sm whitespace-pre-wrap">
+        {formatted.split('\n').map((line, i) => {
+          // Highlight keys in quotes
+          const highlightedLine = line.replace(
+            /"([^"]+)":/g,
+            '<span class="text-yellow-500">"$1"</span>:',
+          );
+
+          return <div key={i} dangerouslySetInnerHTML={{ __html: highlightedLine }} />;
+        })}
+      </code>
+    );
+  } catch (e) {
+    // Return error message if JSON parsing fails
+    return <span className="text-red-500">Invalid JSON: {String(e)}</span>;
+  }
+};
+
+// Component for rendering JSON content
+export const JsonContentRenderer: React.FC<{ jsonContent: RulesContent[] }> = ({ jsonContent }) => {
+  return (
+    <div>
+      {jsonContent.map((rule, index) => (
+        <div
+          key={'jsonContent-' + index}
+          className="overflow-y-auto relative flex-1 p-4 mt-4 h-full min-h-0 bg-gray-900 rounded-lg"
+        >
+          <div className="absolute top-4 right-4 flex flex-wrap gap-2">
+            <RulesPreviewCopyDownloadActions
+              rulesContent={[rule]}
+              filePath=".vscode/settings.json"
+            />
+          </div>
+
+          <pre className="font-mono text-sm text-gray-300 whitespace-pre-wrap">
+            {formatJsonWithSyntaxHighlighting(rule.markdown)}
+          </pre>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default JsonContentRenderer;

--- a/src/data/ai-environments.ts
+++ b/src/data/ai-environments.ts
@@ -14,6 +14,7 @@ export type AIEnvironment = `${AIEnvironmentName}`;
 type AIEnvironmentConfig = {
   [key in AIEnvironmentName]: {
     filePath: string;
+    alternativeFilePath?: string;
     docsUrl: string;
   };
 };
@@ -21,6 +22,7 @@ type AIEnvironmentConfig = {
 export const aiEnvironmentConfig: AIEnvironmentConfig = {
   github: {
     filePath: '.github/copilot-instructions.md',
+    alternativeFilePath: '.github/{rule}.instructions.md',
     docsUrl:
       'https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot',
   },

--- a/src/services/rules-builder/RulesBuilderService.ts
+++ b/src/services/rules-builder/RulesBuilderService.ts
@@ -5,7 +5,7 @@ import {
   getLayerByStack,
   getStacksByLibrary,
 } from '../../data/dictionaries.ts';
-import type { RulesContent } from './RulesBuilderTypes.ts';
+import type { RulesContent, SettingsContent } from './RulesBuilderTypes.ts';
 import type { RulesGenerationStrategy } from './RulesGenerationStrategy.ts';
 import { MultiFileRulesStrategy } from './rules-generation-strategies/MultiFileRulesStrategy.ts';
 import { SingleFileRulesStrategy } from './rules-generation-strategies/SingleFileRulesStrategy.ts';
@@ -44,6 +44,24 @@ export class RulesBuilderService {
       stacksByLayer,
       librariesByStack,
     );
+  }
+
+  static generateSettingsContent(selectedLibraries: Library[]): SettingsContent[] {
+    return [
+      {
+        markdown: JSON.stringify([
+          {
+            'github.copilot.chat.codeGeneration.instructions': [
+              selectedLibraries.map((library) => ({
+                path: `.github/${library.toLowerCase()}.instructions.md`,
+              })),
+            ],
+          },
+        ]),
+        label: 'Settings',
+        fileName: 'settings.json',
+      },
+    ];
   }
 
   /**

--- a/src/services/rules-builder/RulesBuilderTypes.ts
+++ b/src/services/rules-builder/RulesBuilderTypes.ts
@@ -1,5 +1,11 @@
 export interface RulesContent {
   markdown: string;
   label: string;
-  fileName: `${string}.mdc`;
+  fileName: `${string}`;
+}
+
+export interface SettingsContent {
+  markdown: string;
+  label: string;
+  fileName: `${string}`;
 }

--- a/src/services/rules-builder/RulesGenerationStrategy.ts
+++ b/src/services/rules-builder/RulesGenerationStrategy.ts
@@ -11,5 +11,6 @@ export interface RulesGenerationStrategy {
     selectedLibraries: Library[],
     stacksByLayer: Record<Layer, Stack[]>,
     librariesByStack: Record<Stack, Library[]>,
+    extension?: string,
   ): RulesContent[];
 }

--- a/src/services/rules-builder/rules-generation-strategies/MultiFileRulesStrategy.ts
+++ b/src/services/rules-builder/rules-generation-strategies/MultiFileRulesStrategy.ts
@@ -14,11 +14,12 @@ export class MultiFileRulesStrategy implements RulesGenerationStrategy {
     selectedLibraries: Library[],
     stacksByLayer: Record<Layer, Stack[]>,
     librariesByStack: Record<Stack, Library[]>,
+    extension = 'mdc',
   ): RulesContent[] {
     const projectMarkdown = `# AI Rules for ${projectName}\n\n${projectDescription}\n\n`;
     const noSelectedLibrariesMarkdown = `---\n\n👈 Use the Rule Builder on the left or drop dependency file here`;
     const projectLabel = 'Project',
-      projectFileName = 'project.mdc';
+      projectFileName = `project.${extension}`;
 
     const markdowns: RulesContent[] = [];
 
@@ -38,6 +39,7 @@ export class MultiFileRulesStrategy implements RulesGenerationStrategy {
               stack,
               library,
               libraryRules: getRulesForLibrary(library),
+              extension,
             }),
           );
         });
@@ -47,19 +49,26 @@ export class MultiFileRulesStrategy implements RulesGenerationStrategy {
     return markdowns;
   }
 
+  createFileName = ({ label, extension = 'mdc' }: { label: string; extension?: string }) => {
+    const fileName: RulesContent['fileName'] = `${slugify(label)}.${extension}`;
+    return fileName;
+  };
+
   private buildRulesContent({
     libraryRules,
     layer,
     stack,
     library,
+    extension = 'mdc',
   }: {
     libraryRules: string[];
     layer: string;
     stack: string;
     library: string;
+    extension?: string;
   }): RulesContent {
     const label = `${layer} - ${stack} - ${library}`;
-    const fileName: RulesContent['fileName'] = `${slugify(`${layer}-${stack}-${library}`)}.mdc`;
+    const fileName = this.createFileName({ label, extension });
     const content =
       libraryRules.length > 0
         ? `${libraryRules.map((rule) => `- ${rule}`).join('\n')}`

--- a/src/services/rules-builder/rules-generation-strategies/SingleFileRulesStrategy.ts
+++ b/src/services/rules-builder/rules-generation-strategies/SingleFileRulesStrategy.ts
@@ -13,11 +13,12 @@ export class SingleFileRulesStrategy implements RulesGenerationStrategy {
     selectedLibraries: Library[],
     stacksByLayer: Record<Layer, Stack[]>,
     librariesByStack: Record<Stack, Library[]>,
+    extension = 'mdc',
   ): RulesContent[] {
     const projectMarkdown = `# AI Rules for ${projectName}\n\n${projectDescription}\n\n`;
     const noSelectedLibrariesMarkdown = `---\n\n👈 Use the Rule Builder on the left or drop dependency file here`;
     const projectLabel = 'Project',
-      projectFileName = 'project.mdc';
+      projectFileName = `project.${extension}`;
 
     let markdown = projectMarkdown;
 
@@ -27,7 +28,7 @@ export class SingleFileRulesStrategy implements RulesGenerationStrategy {
     }
 
     markdown += this.generateLibraryMarkdown(stacksByLayer, librariesByStack);
-    return [{ markdown, label: 'All Rules', fileName: 'rules.mdc' }];
+    return [{ markdown, label: 'All Rules', fileName: `rules.${extension}` }];
   }
 
   private generateLibraryMarkdown(

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -17,12 +17,18 @@ interface ProjectState {
   setProjectDescription: (description: string) => void;
   setSelectedEnvironment: (environment: AIEnvironment) => void;
   setHydrated: () => void;
+  setMultiFileEnvironment: (isMultiFile: boolean) => void;
 }
 
 export const multiFileEnvironments: ReadonlySet<AIEnvironment> = new Set<AIEnvironment>([
   AIEnvironmentName.Cline,
   AIEnvironmentName.Cursor,
 ]);
+
+export const adaptableFileEnvironments: ReadonlySet<AIEnvironment> = new Set<AIEnvironment>([
+  AIEnvironmentName.GitHub,
+]);
+
 export const initialEnvironment: Readonly<AIEnvironment> = AIEnvironmentName.Cursor;
 
 // Create a store with persistence
@@ -39,12 +45,15 @@ export const useProjectStore = create<ProjectState>()(
       // Actions
       setProjectName: (name: string) => set({ projectName: name }),
       setProjectDescription: (description: string) => set({ projectDescription: description }),
-      setSelectedEnvironment: (environment: AIEnvironment) =>
-        set({
+      setSelectedEnvironment: (environment: AIEnvironment) => {
+        return set({
           selectedEnvironment: environment,
           isMultiFileEnvironment: multiFileEnvironments.has(environment),
-        }),
+        });
+      },
       setHydrated: () => set({ isHydrated: true }),
+      setMultiFileEnvironment: (isMultiFile: boolean) =>
+        set({ isMultiFileEnvironment: isMultiFile }),
     }),
     {
       name: 'ai-rules-project-storage',
@@ -57,6 +66,7 @@ export const useProjectStore = create<ProjectState>()(
       // Set hydration flag when storage is hydrated
       onRehydrateStorage: () => (state) => {
         if (state) {
+          state.setMultiFileEnvironment(multiFileEnvironments.has(state.selectedEnvironment));
           state.setHydrated();
         }
       },


### PR DESCRIPTION
# Description

Add support for [github split instructions](https://code.visualstudio.com/docs/copilot/copilot-customization#_reusable-prompt-files-experimental):


Uploading Nagranie z ekranu 2025-05-12 o 03.27.54.mov…


Fix bug regarding stale isMultiFileEnvironment after reload:

https://github.com/user-attachments/assets/6ece1cf0-935d-4f66-9f58-90d262d9400c



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit Tests

## Important Note for Fork-Based PRs

If you're submitting a PR from a forked repository, please note that E2E tests require specific repository-level environment (`integration`) and secrets to be set up. These are described in `.env.example` and include:

```bash
PUBLIC_ENV_NAME=integration
SUPABASE_URL=###
SUPABASE_PUBLIC_KEY=###

E2E_USERNAME_ID=###
E2E_USERNAME=###
E2E_PASSWORD=###
```

Please ensure these are properly configured in your fork's repository settings under "Secrets and variables" → "Actions" before running E2E tests.
