### PR TITLE
Feature/37 reflect selected rules in the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Create so called "rules for AI" written in Markdown, used by tools such as GitHu
 
 1. Install Supabase CLI
 
+  Check [Supabase docs](https://supabase.com/docs/guides/local-development?queryGroups=package-manager&package-manager=brew#quickstart) for local setup reference.
+
    ```bash
-   brew install supabase
+   brew install supabase/tap/supabase
    ```
 
 2. Start Supabase (requires local Docker)

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "clsx": "^2.1.1",
         "fflate": "^0.8.2",
         "lucide-react": "0.479.0",
+        "lz-string": "^1.5.0",
         "react": "18.3.0",
         "react-dom": "18.3.0",
         "react-hook-form": "7.55.0",
@@ -7411,7 +7412,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "clsx": "^2.1.1",
     "fflate": "^0.8.2",
     "lucide-react": "0.479.0",
+    "lz-string": "^1.5.0",
     "react": "18.3.0",
     "react-dom": "18.3.0",
     "react-hook-form": "7.55.0",

--- a/src/components/TwoPane.tsx
+++ b/src/components/TwoPane.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { RuleBuilder } from './rule-builder';
 import { RulePreview } from './rule-preview';
 import CollectionsSidebar from './rule-collections/CollectionsSidebar';
 import { MobileNavigation } from './MobileNavigation';
 import { useNavigationStore } from '../store/navigationStore';
 import { isFeatureEnabled } from '../features/featureFlags';
+import { useTechStackStore } from '../store/techStackStore';
 
-export default function TwoPane() {
+function RulesPane() {
   const { activePanel, isSidebarOpen, toggleSidebar, setSidebarOpen } = useNavigationStore();
   const isCollectionsEnabled = isFeatureEnabled('authOnUI');
 
@@ -50,4 +51,25 @@ export default function TwoPane() {
       <MobileNavigation />
     </div>
   );
+}
+
+type TwoPaneProps = {
+  initialUrl: URL;
+};
+
+export default function TwoPane({ initialUrl }: TwoPaneProps) {
+  const { anyLibrariesToLoad } = useTechStackStore();
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  const shouldWaitForHydration = anyLibrariesToLoad(initialUrl) && !isHydrated;
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  if (shouldWaitForHydration) {
+    return <div>Loading...</div>;
+  }
+
+  return <RulesPane />;
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,13 +4,15 @@ import Topbar from '../components/Topbar';
 import TwoPane from '../components/TwoPane';
 import Footer from '../components/Footer';
 const user = Astro.locals.user;
+
+const initialUrl = Astro.url;
 ---
 
 <Layout>
   <div class="flex flex-col h-screen max-h-screen bg-gray-950 overflow-hidden">
     <Topbar client:load initialUser={user} />
     <main class="flex-grow overflow-auto">
-      <TwoPane client:load />
+      <TwoPane client:load initialUrl={initialUrl} />
     </main>
     <Footer client:load />
   </div>

--- a/src/store/storage/urlStorage.test.ts
+++ b/src/store/storage/urlStorage.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { createUrlStorage, doesUrlContainState } from './urlStorage';
+import type { StorageValue } from 'zustand/middleware';
+
+// make the compressing/decompressing methods more readable for testing
+vi.mock('lz-string', () => ({
+  compressToEncodedURIComponent: vi.fn((str) => `compressed:${str}`),
+  decompressFromEncodedURIComponent: vi.fn((str) => str.replace('compressed:', '')),
+}));
+
+type TestState = { foo: string };
+const TEST_KEY = 'testKey';
+const TEST_STATE: TestState = { foo: 'bar' };
+const TEST_VALUE: StorageValue<TestState> = { state: TEST_STATE };
+const COMPRESSED_VALUE = 'compressed:' + JSON.stringify(TEST_VALUE);
+
+describe('UrlStorage', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('client-side, storage', () => {
+    const spies = {
+      location: vi.spyOn(window, 'location', 'get'),
+      pushState: vi.fn(),
+    };
+
+    function setLocationSearch(search: string) {
+      spies.location.mockReturnValue({
+        search,
+        pathname: '/test',
+        hash: '',
+      } as unknown as Location);
+    }
+
+    beforeEach(() => {
+      spies.location = vi.spyOn(window, 'location', 'get');
+      setLocationSearch('');
+      spies.pushState = vi.fn();
+      global.window.history.pushState = spies.pushState;
+    });
+
+    afterEach(() => {
+      spies.location.mockRestore();
+    });
+
+    it('contains null if key is not present', () => {
+      setLocationSearch('');
+      const storage = createUrlStorage<TestState>();
+      expect(storage.getItem(TEST_KEY)).toBeNull();
+    });
+
+    it('contains parsed value if key is present', () => {
+      setLocationSearch(`?${TEST_KEY}=${COMPRESSED_VALUE}`);
+      const storage = createUrlStorage<TestState>();
+      expect(storage.getItem(TEST_KEY)).toEqual(TEST_VALUE);
+    });
+
+    it('contains compressed value and updates URL', () => {
+      const storage = createUrlStorage<TestState>();
+      storage.setItem(TEST_KEY, TEST_VALUE);
+
+      // Construct expected search string using URLSearchParams for consistent encoding
+      const expectedParams = new URLSearchParams();
+      expectedParams.set(TEST_KEY, COMPRESSED_VALUE);
+      const expectedSearchString = expectedParams.toString();
+      const expectedUrl = window.location.pathname + '?' + expectedSearchString;
+
+      expect(window.history.pushState).toHaveBeenCalledWith({}, '', expectedUrl);
+    });
+
+    it('removes key and updates URL', () => {
+      setLocationSearch(`?${TEST_KEY}=${COMPRESSED_VALUE}`);
+      const storage = createUrlStorage<TestState>();
+      storage.removeItem(TEST_KEY);
+
+      // After removal, the param should not be present, queryParams.toString() will be empty
+      const expectedUrl = window.location.pathname + '?';
+      expect(window.history.pushState).toHaveBeenCalledWith({}, '', expectedUrl);
+    });
+  });
+
+  describe('server-side', () => {
+    let originalWindow: Window & typeof globalThis;
+
+    beforeAll(() => {
+      originalWindow = global.window;
+      // @ts-expect-error: Simulate server-side by deleting window
+      delete global.window;
+    });
+
+    afterAll(() => {
+      global.window = originalWindow!;
+    });
+
+    it('does not throw and does not update URL', () => {
+      const storage = createUrlStorage<TestState>();
+      expect(() => storage.setItem(TEST_KEY, TEST_VALUE)).not.toThrow();
+      expect(() => storage.removeItem(TEST_KEY)).not.toThrow();
+    });
+  });
+});
+
+describe('doesUrlContainState', () => {
+  it('should return true if param exists', () => {
+    const url = new URL('http://localhost/?rulesFromUrl=bar');
+    expect(doesUrlContainState(url, 'rulesFromUrl')).toBe(true);
+  });
+
+  it('should return false if param does not exist', () => {
+    const url = new URL('http://localhost/?someOtherParam=bar');
+    expect(doesUrlContainState(url, 'rulesFromUrl')).toBe(false);
+  });
+
+  it('should return false if param is not present', () => {
+    const url = new URL('http://localhost/');
+    expect(doesUrlContainState(url, 'rulesFromUrl')).toBe(false);
+  });
+});

--- a/src/store/storage/urlStorage.ts
+++ b/src/store/storage/urlStorage.ts
@@ -1,0 +1,49 @@
+import type { PersistStorage, StorageValue } from 'zustand/middleware';
+import * as LZString from 'lz-string';
+
+const { compressToEncodedURIComponent, decompressFromEncodedURIComponent } = LZString;
+
+class UrlStorage<TState> implements PersistStorage<TState> {
+  private queryParams: URLSearchParams;
+
+  constructor() {
+    if (this.isServerSide()) {
+      this.queryParams = new URLSearchParams('');
+    } else {
+      this.queryParams = new URLSearchParams(window.location.search);
+    }
+  }
+
+  getItem(name: string): StorageValue<TState> | Promise<StorageValue<TState> | null> | null {
+    const value = this.queryParams.get(name);
+    if (!value) return null;
+    return JSON.parse(decompressFromEncodedURIComponent(value));
+  }
+
+  setItem(name: string, value: StorageValue<TState>): unknown | Promise<unknown> {
+    this.queryParams.set(name, compressToEncodedURIComponent(JSON.stringify(value)));
+    this.updateUrl();
+
+    return Promise.resolve();
+  }
+
+  removeItem(name: string): unknown | Promise<unknown> {
+    this.queryParams.delete(name);
+    this.updateUrl();
+
+    return Promise.resolve();
+  }
+
+  private updateUrl() {
+    if (this.isServerSide()) return;
+    window.history.pushState({}, '', window.location.pathname + '?' + this.queryParams.toString());
+  }
+
+  private isServerSide() {
+    return typeof window === 'undefined';
+  }
+}
+
+export const createUrlStorage = <TState>() => new UrlStorage<TState>();
+export const doesUrlContainState = (url: URL, name: string): boolean =>
+  url.searchParams.get(name) !== null;


### PR DESCRIPTION
# Description

Solving the #37

https://github.com/user-attachments/assets/57fb8dfc-c941-4e32-ad30-8a5307db5a71


## Type of change

- [x] New feature (non-breaking change which adds functionality)

Please see #37

## Notes

### Query params format

I considered two options for the data format in the URL's query parameters:

1. Transform for readability, like `rules=REACT&VUE` (use directory keys for clarity).
2. Retain the Zustand state shape.

I chose option 2, keeping the Zustand state shape because:

- It includes the `version` field, allowing for data migration using Zustand's persistence features if needed.
- It's the simplest solution.

### URL query params length limitations

Since URL parameters can be lengthy, I've compressed them using [LZ-String](https://snyk.io/advisor/npm-package/lz-string). The package is "complete," so there's no active development, including the absence of an ESM version, which I find acceptable.

### Hydration of the zustand state

To overcome the hydration issues, I've decided to show a placeholder if there is a need for hydration (if we have any state in URL params).
Placeholder is plain "Loading..." (I will put it in `translations.ts` or add some nice skeleton - but rooting for your feedback on the approach first 😊)

More context in tldr; form - Zustand, and state management is a client thing. Since there are hacky ways of enabling it on server-side, it is not recommended.

More on that: [zustand main readme](https://github.com/pmndrs/zustand?tab=readme-ov-file#readingwriting-state-and-reacting-to-changes-outside-of-components) and [the whole thread it points to](https://github.com/pmndrs/zustand/discussions/2200). With some [interesting way of doing it 😅](https://github.com/pmndrs/zustand/discussions/2200#discussioncomment-11498163)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit Tests - Added some new ones
- [ ] E2E Tests - The new ones have not been added yet. Rooting for initial feedback first

## Important Note for Fork-Based PRs

- [ ] TODO MM: setup the GHA for running the E2E tests in my fork

If you're submitting a PR from a forked repository, please note that E2E tests require specific repository-level environment (`integration`) and secrets to be set up. These are described in `.env.example` and include:

```bash
PUBLIC_ENV_NAME=integration
SUPABASE_URL=###
SUPABASE_PUBLIC_KEY=###

E2E_USERNAME_ID=###
E2E_USERNAME=###
E2E_PASSWORD=###
```

Please ensure these are properly configured in your fork's repository settings under "Secrets and variables" → "Actions" before running E2E tests.
