### PR TITLE
fix: enable dependency uploads without login

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -9,6 +9,7 @@ const RATE_LIMIT_CONFIG: { [path: string]: number } = {
   '/api/auth/signup': 60,
   '/api/auth/reset-password': 60,
   '/api/auth/update-password': 60,
+  '/api/upload-dependencies': 5,
 };
 
 const rateLimiter = defineMiddleware(async ({ cookies, url }, next) => {

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -51,6 +51,7 @@ const PUBLIC_PATHS = [
   '/api/auth/reset-password',
   '/api/auth/verify-reset-token',
   '/api/captcha/verify',
+  '/api/upload-dependencies',
   '/privacy/pl',
   '/privacy/en',
 ];


### PR DESCRIPTION
# Description

Before the [auth implementation](https://github.com/przeprogramowani/ai-rules-builder/pull/22), uploading a dependency file didn't require login. This behavior is also described in `project-prd.md` under `US-002`, with no mention of authentication.

Current state:
![image](https://github.com/user-attachments/assets/73c9726a-d577-47e3-bf6d-218600d48dd5)

![image](https://github.com/user-attachments/assets/5e027ac2-89ca-409e-8760-86d874769b5f)

The auth PR introduced `PUBLIC_PATHS`, but it looks like the `upload-dependencies` endpoint was missed. This PR fixes that by marking it as public - no login required.

If uploading dependencies should require login, then we should either:
- Hide the upload button for unauthenticated users
- Or at least communicate that login is required before allowing the action

If we agree this endpoint should stay public, then this PR is good to go 🟢.

I haven’t added any `RATE_LIMIT_CONFIG` for this endpoint. If you think we should add something lightweight (e.g. 1 upload every 5 seconds), let me know and I’ll include it.

Br,
Kacper

## Roadmap alignment

- [ ] I have opened an issue first and received approval before working on this PR.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [X] Manual Tests
- [ ] Unit Tests
- [ ] E2E Tests