### PR TITLE
Refactor keyboard activation handling across rule builder

### DIFF
--- a/src/components/rule-builder/LibraryItem.tsx
+++ b/src/components/rule-builder/LibraryItem.tsx
@@ -1,11 +1,11 @@
 import { Check } from 'lucide-react';
-import type { KeyboardEvent } from 'react';
 import React from 'react';
 import { Library } from '../../data/dictionaries';
 import { getLibraryTranslation } from '../../i18n/translations';
 import type { LayerType } from '../../styles/theme';
 import { getLayerClasses } from '../../styles/theme';
 import { useAccordionContentOpen } from '../ui/Accordion';
+import { useKeyboardActivation } from '../../hooks/useKeyboardActivation';
 
 interface LibraryItemProps {
   library: Library;
@@ -18,13 +18,7 @@ export const LibraryItem: React.FC<LibraryItemProps> = React.memo(
   ({ library, isSelected, onToggle, layerType }) => {
     const isParentAccordionOpen = useAccordionContentOpen();
     const itemClasses = getLayerClasses.libraryItem(layerType, isSelected);
-
-    const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        onToggle(library);
-      }
-    };
+    const handleKeyDown = useKeyboardActivation<HTMLButtonElement>();
 
     return (
       <button

--- a/src/components/rule-builder/SearchInput.tsx
+++ b/src/components/rule-builder/SearchInput.tsx
@@ -1,6 +1,7 @@
 import { Search, X } from 'lucide-react';
-import type { ChangeEvent, KeyboardEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import React, { useCallback, useRef, useState } from 'react';
+import { useKeyboardActivation } from '../../hooks/useKeyboardActivation';
 
 interface SearchInputProps {
   searchQuery: string;
@@ -32,15 +33,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
     inputRef.current?.focus();
   }, [setSearchQuery]);
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        handleClear();
-      }
-    },
-    [handleClear],
-  );
+  const handleClearKeyDown = useKeyboardActivation<HTMLButtonElement>();
 
   return (
     <div
@@ -67,7 +60,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
         <button
           className="absolute right-3 top-1/2 p-1 text-gray-400 rounded-full -translate-y-1/2 hover:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:text-gray-200"
           onClick={handleClear}
-          onKeyDown={handleKeyDown}
+          onKeyDown={handleClearKeyDown}
           tabIndex={0}
           aria-label="Clear search"
         >

--- a/src/components/rule-builder/SelectedRules.tsx
+++ b/src/components/rule-builder/SelectedRules.tsx
@@ -1,9 +1,9 @@
 import { X } from 'lucide-react';
 import React from 'react';
-import type { KeyboardEvent } from 'react';
 import { Library } from '../../data/dictionaries';
 import type { LayerType } from '../../styles/theme';
 import { getLayerClasses } from '../../styles/theme';
+import { useKeyboardActivation } from '../../hooks/useKeyboardActivation';
 
 interface SelectedRulesProps {
   selectedLibraries: Library[];
@@ -13,12 +13,7 @@ interface SelectedRulesProps {
 
 export const SelectedRules: React.FC<SelectedRulesProps> = React.memo(
   ({ selectedLibraries, unselectLibrary, getLibraryLayerType }) => {
-    const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, library: Library) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        unselectLibrary(library);
-      }
-    };
+    const handleRemoveKeyDown = useKeyboardActivation<HTMLButtonElement>();
 
     if (selectedLibraries.length === 0) {
       return null;
@@ -43,7 +38,7 @@ export const SelectedRules: React.FC<SelectedRulesProps> = React.memo(
                 <span>{library}</span>
                 <button
                   onClick={() => unselectLibrary(library)}
-                  onKeyDown={(e) => handleKeyDown(e, library)}
+                  onKeyDown={handleRemoveKeyDown}
                   className={`text-white opacity-70 cursor-pointer hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-1 ${getLayerClasses.focusRing(layerType)}`}
                   aria-label={`Remove ${library} rule`}
                   tabIndex={0}

--- a/src/components/rule-collections/CollectionListEntry.tsx
+++ b/src/components/rule-collections/CollectionListEntry.tsx
@@ -4,6 +4,7 @@ import type { Collection } from '../../store/collectionsStore';
 import { useCollectionsStore } from '../../store/collectionsStore';
 import DeletionDialog from './DeletionDialog';
 import SaveCollectionDialog from './SaveCollectionDialog';
+import { useKeyboardActivation } from '../../hooks/useKeyboardActivation';
 
 interface CollectionListEntryProps {
   collection: Collection;
@@ -74,6 +75,10 @@ export const CollectionListEntry: React.FC<CollectionListEntryProps> = ({
     }
   };
 
+  const handleActionKeyDown = useKeyboardActivation<HTMLDivElement>({
+    stopPropagation: true,
+  });
+
   return (
     <>
       <button
@@ -101,12 +106,7 @@ export const CollectionListEntry: React.FC<CollectionListEntryProps> = ({
               tabIndex={0}
               className="p-1.5 rounded-md text-gray-400 hover:text-blue-400 hover:bg-gray-700/50 opacity-0 group-hover:opacity-100 transition-colors cursor-pointer"
               aria-label={`Edit ${collection.name}`}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleEditClick(e as unknown as React.MouseEvent);
-                }
-              }}
+              onKeyDown={handleActionKeyDown}
             >
               <Pencil className="size-4" />
             </div>
@@ -117,12 +117,7 @@ export const CollectionListEntry: React.FC<CollectionListEntryProps> = ({
               tabIndex={0}
               className="p-1.5 rounded-md text-gray-400 hover:text-red-400 hover:bg-gray-700/50 opacity-0 group-hover:opacity-100 cursor-pointer transition-colors"
               aria-label={`Delete ${collection.name}`}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleDeleteClick(e as unknown as React.MouseEvent);
-                }
-              }}
+              onKeyDown={handleActionKeyDown}
             >
               <Trash2 className="size-4" />
             </div>

--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown } from 'lucide-react';
-import type { KeyboardEvent } from 'react';
 import React, { createContext, useContext } from 'react';
 import { transitions } from '../../styles/theme';
+import { useKeyboardActivation } from '../../hooks/useKeyboardActivation';
 
 // Create a context to track accordion open state
 const AccordionContentContext = createContext<boolean>(false);
@@ -66,13 +66,11 @@ export const AccordionTrigger: React.FC<AccordionTriggerProps> = React.memo(
     // Top-level accordion triggers should always be focusable (tabIndex=0)
     // Only nested triggers should check parent state
     const shouldBeFocusable = isRoot || isParentAccordionOpen;
-
-    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
+    const handleKeyDown = useKeyboardActivation<HTMLDivElement>({
+      onActivate: () => {
         onClick?.();
-      }
-    };
+      },
+    });
 
     return (
       <div

--- a/src/hooks/useKeyboardActivation.ts
+++ b/src/hooks/useKeyboardActivation.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+import type { KeyboardEvent } from 'react';
+
+const DEFAULT_ACTIVATION_KEYS = ['Enter', ' ', 'Space', 'Spacebar'] as const;
+
+interface UseKeyboardActivationOptions<E extends HTMLElement> {
+  keys?: readonly string[];
+  onActivate?: (event: KeyboardEvent<E>) => void;
+  preventDefault?: boolean;
+  stopPropagation?: boolean;
+}
+
+export const useKeyboardActivation = <E extends HTMLElement = HTMLElement>(
+  options: UseKeyboardActivationOptions<E> = {},
+) => {
+  const {
+    keys = DEFAULT_ACTIVATION_KEYS,
+    onActivate,
+    preventDefault = true,
+    stopPropagation = false,
+  } = options;
+
+  return useCallback(
+    (event: KeyboardEvent<E>) => {
+      if (!keys.includes(event.key)) {
+        return;
+      }
+
+      if (preventDefault) {
+        event.preventDefault();
+      }
+
+      if (stopPropagation) {
+        event.stopPropagation();
+      }
+
+      if (onActivate) {
+        onActivate(event);
+        return;
+      }
+
+      const target = event.currentTarget as HTMLElement | null;
+      if (target && typeof target.click === 'function') {
+        target.click();
+      }
+    },
+    [keys, onActivate, preventDefault, stopPropagation],
+  );
+};
+
+export default useKeyboardActivation;

--- a/tests/hooks/useKeyboardActivation.test.tsx
+++ b/tests/hooks/useKeyboardActivation.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import useKeyboardActivation from '@/hooks/useKeyboardActivation';
+
+type UseKeyboardActivationOptions = Parameters<typeof useKeyboardActivation>[0];
+
+const TestButton = ({
+  options,
+  onClick,
+}: {
+  options?: UseKeyboardActivationOptions;
+  onClick?: () => void;
+}) => {
+  const handleActivation = useKeyboardActivation<HTMLButtonElement>(options);
+
+  return (
+    <button data-testid="keyboard-target" onClick={onClick} onKeyDown={handleActivation}>
+      Activate
+    </button>
+  );
+};
+
+describe('useKeyboardActivation', () => {
+  const dispatchKeyEvent = (element: HTMLElement, key: string) => {
+    const event = createEvent.keyDown(element, { key, bubbles: true, cancelable: true });
+    fireEvent(element, event);
+    return event;
+  };
+
+  it('delegates activation to click for default keys', () => {
+    const handleClick = vi.fn();
+    render(<TestButton onClick={handleClick} />);
+
+    const button = screen.getByTestId('keyboard-target');
+    const event = dispatchKeyEvent(button, 'Enter');
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.cancelBubble).toBe(false);
+  });
+
+  it('supports activating with the space bar', () => {
+    const handleClick = vi.fn();
+    render(<TestButton onClick={handleClick} />);
+
+    const button = screen.getByTestId('keyboard-target');
+    dispatchKeyEvent(button, ' ');
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects custom activation keys', () => {
+    const handleClick = vi.fn();
+    render(<TestButton options={{ keys: ['k'] }} onClick={handleClick} />);
+
+    const button = screen.getByTestId('keyboard-target');
+    dispatchKeyEvent(button, 'Enter');
+    dispatchKeyEvent(button, 'k');
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('can skip preventDefault when configured', () => {
+    const handleClick = vi.fn();
+    render(<TestButton options={{ preventDefault: false }} onClick={handleClick} />);
+
+    const button = screen.getByTestId('keyboard-target');
+    const event = dispatchKeyEvent(button, 'Enter');
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('can stop event propagation when requested', () => {
+    const parentHandler = vi.fn();
+    render(
+      <div onKeyDown={parentHandler}>
+        <TestButton options={{ stopPropagation: true }} />
+      </div>,
+    );
+
+    const button = screen.getByTestId('keyboard-target');
+    dispatchKeyEvent(button, 'Enter');
+
+    expect(parentHandler).not.toHaveBeenCalled();
+  });
+
+  it('invokes custom activation callback and does not click automatically', () => {
+    const handleClick = vi.fn();
+    const onActivate = vi.fn();
+    render(<TestButton options={{ onActivate }} onClick={handleClick} />);
+
+    const button = screen.getByTestId('keyboard-target');
+    const event = dispatchKeyEvent(button, 'Enter');
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(onActivate).toHaveBeenCalledWith(expect.objectContaining({ key: 'Enter' }));
+    expect(handleClick).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable `useKeyboardActivation` hook to normalize keyboard-initiated activation
- update rule builder and collection UI elements to rely on the shared handler for Enter/Space support
- add Vitest coverage for the shared hook to verify default/callback activation behavior

## Testing
- npm run lint:check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d108a3147c8322b20bb7c70f8388b2